### PR TITLE
update site URL

### DIFF
--- a/addons/plugin.video.hdrezka.tv/resources/settings.xml
+++ b/addons/plugin.video.hdrezka.tv/resources/settings.xml
@@ -6,7 +6,7 @@
         <setting id="quality" type="labelenum" label="Video quality" values="select|360p|480p|720p|1080p" default="select"/>
         <setting id="translator" type="labelenum" label="Use translator" values="default|select" default="default"/>
         <setting id="dom_protocol" type="labelenum" label="Protocol" values="http|https" default="https"/>        
-        <setting id="domain" type="text" label="Site URL" default="hdrezka.ag"/>
+        <setting id="domain" type="text" label="Site URL" default="rezka.ag"/>
         <setting id="description" type="bool" label="Get media description" default="true" />
         <setting type="bool" id="united_search" visible="false" default="true" />
         <setting type="text" id="us_command" visible="false" default="mode=search&keyword=" />


### PR DESCRIPTION
there was an error message in Kodi 19 and plugin didn`t start because site had been moved to another domain(though there is still alias available, while browsing on web)