### PR TITLE
Added proxy setup to be affected for HTTPS URLs

### DIFF
--- a/addons/plugin.video.hdrezka.tv/default.py
+++ b/addons/plugin.video.hdrezka.tv/default.py
@@ -55,7 +55,10 @@ class HdrezkaTV:
             return False
         proxy_protocol = self.addon.getSetting('protocol')
         proxy_url = self.addon.getSetting('proxy_url')
-        return {'http': proxy_protocol + '://' + proxy_url}
+        return {
+            'http': proxy_protocol + '://' + proxy_url,
+            'https': proxy_protocol + '://' + proxy_url
+        }
 
     def get_response(self, url, data=None, headers=None, referer='http://www.random.org'):
         if not headers:


### PR DESCRIPTION
Python requests module not affected proxy-settings for secured calls when defined dictionary with http-only key.
Ref https://requests.readthedocs.io/en/master/user/advanced/#proxies

For completely support proxy, settings should be defined both for http and https keys.