### PR TITLE
Fixed requesting stream with is_director param

### DIFF
--- a/addons/plugin.video.hdrezka.tv/default.py
+++ b/addons/plugin.video.hdrezka.tv/default.py
@@ -363,6 +363,10 @@ class HdrezkaTV:
             "translator_id": idt,
             "action": action
         }
+        is_director = common.parseDOM(div, 'li', attrs={'data-translator_id': idt}, ret='data-director')
+        if is_director:
+            data['is_director'] = is_director[0]
+
         headers = {
             "Host": self.domain,
             "Origin": "http://" + self.domain,
@@ -370,11 +374,11 @@ class HdrezkaTV:
             "User-Agent": USER_AGENT,
             "X-Requested-With": "XMLHttpRequest"
         }
-        
+
         #{"success":true,"message":"","url":"[360p]https:\/\/stream.voidboost.cc\/8\/8\/1\/3\/3\/ddddfc45662e813d93128d783cb46e7f:2020101118\/3dxox.mp4:hls:manifest.m3u8 or https:\/\/stream.voidboost.cc\/61e68929526165ffb2e5483777a4bd94:2020101118\/8\/8\/1\/3\/3\/3dxox.mp4,[480p]https:\/\/stream.voidboost.cc\/8\/8\/1\/3\/3\/ddddfc45662e813d93128d783cb46e7f:2020101118\/ppjm0.mp4:hls:manifest.m3u8 or https:\/\/stream.voidboost.cc\/6498b090482768d1433d456b2e35c46a:2020101118\/8\/8\/1\/3\/3\/ppjm0.mp4,[720p]https:\/\/stream.voidboost.cc\/8\/8\/1\/3\/3\/ddddfc45662e813d93128d783cb46e7f:2020101118\/0w0az.mp4:hls:manifest.m3u8 or https:\/\/stream.voidboost.cc\/b10164963f454ad391b2a13460568561:2020101118\/8\/8\/1\/3\/3\/0w0az.mp4,[1080p]https:\/\/stream.voidboost.cc\/8\/8\/1\/3\/3\/ddddfc45662e813d93128d783cb46e7f:2020101118\/n9qju.mp4:hls:manifest.m3u8 or https:\/\/stream.voidboost.cc\/b8a860d0938b593ed4b64723944b9a12:2020101118\/8\/8\/1\/3\/3\/n9qju.mp4,[1080p Ultra]https:\/\/stream.voidboost.cc\/8\/8\/1\/3\/3\/ddddfc45662e813d93128d783cb46e7f:2020101118\/4l9xx.mp4:hls:manifest.m3u8 or https:\/\/stream.voidboost.cc\/13c067a1dcd54be75007a74bde421b17:2020101118\/8\/8\/1\/3\/3\/4l9xx.mp4","quality":"480p","subtitle":"[\u0420\u0443\u0441\u0441\u043a\u0438\u0439]https:\/\/static.voidboost.com\/view\/BmdZqxHeI9zXhhEWUUP70g\/1602429855\/8\/8\/1\/3\/3\/c1lz5sebdx.vtt,[\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430]https:\/\/static.voidboost.com\/view\/F8mGgsIZee6XMjvtXSojhQ\/1602429855\/8\/8\/1\/3\/3\/f0zfov3en4.vtt,[English]https:\/\/static.voidboost.com\/view\/enBDXHLd9y6OByIGY8AiZQ\/1602429855\/8\/8\/1\/3\/3\/ut8ik78tq5.vtt","subtitle_lns":{"off":"","\u0420\u0443\u0441\u0441\u043a\u0438\u0439":"ru","\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430":"ua","English":"en"},"subtitle_def":"ru","thumbnails":"\/ajax\/get_cdn_tiles\/0\/32362\/?t=1602170655"}
-        
+
         response = self.post_response(self.url + "/ajax/get_cdn_series/", data, headers).json()
-        
+
         subtitles = None
         if (action == "get_movie"):
             playlist = [response["url"] ]
@@ -412,15 +416,15 @@ class HdrezkaTV:
         title = common.parseDOM(content, "h1")[0]
         post_id = common.parseDOM(content, "input", attrs={"id": "post_id"}, ret="value")[0]
         idt = "0"
-        try:  
+        try:
            idt = common.parseDOM(content, "li", attrs={"class": "b-translator__item active"}, ret="data-translator_id")[0]
         except:
-           try: 
+           try:
                idt = response.text.split("sof.tv.initCDNSeriesEvents")[-1].split("{")[0]
                idt = idt.split(",")[1].strip()
            except:
                pass
-        subtitles = None       
+        subtitles = None
         tvshow = common.parseDOM(response.text, "div", attrs={"id": "simple-episodes-tabs"})
         if tvshow:
             if self.translator == "select":
@@ -447,10 +451,10 @@ class HdrezkaTV:
             if (self.translator == "select"):
                 content, idt, subtitles = self.selectTranslator3(content[0], content, post_id, url, idt, "get_movie")
             data = content[0].split('"streams":"')[-1].split('",')[0]
-                
+
             links = self.get_links(data)
             self.selectQuality(links, title, image, subtitles)
-            
+
         xbmcplugin.setContent(self.handle, 'episodes')
         xbmcplugin.endOfDirectory(self.handle, True)
 
@@ -598,7 +602,7 @@ class HdrezkaTV:
                 keyword = kbd.getText()
 
             history.add_to_history(keyword)
-             
+
         return keyword
 
     def search(self, keyword, external):
@@ -677,7 +681,7 @@ class HdrezkaTV:
                 "X-Requested-With": "XMLHttpRequest"
             }
             response = self.post_response(self.url + "/ajax/get_cdn_series/", data, headers).json()
-            data = response["url"] 
+            data = response["url"]
         links = self.get_links(data)
         self.selectQuality(links, title, image, None)
         xbmcplugin.setContent(self.handle, 'episodes')


### PR DESCRIPTION
Hello
Some movies with director cut streams are not accessible: server responses with the error
`{'success': False, 'message': 'Время сессии истекло. Пожалуйста, обновите страницу и повторите попытку'}`

After some investigation, I'd found that it happens because of the missing parameter "is_director" in the request. 
Default behavior (with the error):
```
    with Session() as session:
        response = session.post(
            'https://hdrezka.sh/ajax/get_cdn_series/',
            cookies={
                "dle_user_token": "64db22de57884b11f90a5c74c0637a5c",
                "PHPSESSID": "ag2dm7q3klj3cdupf1loaerc93"
            },
            data={
                'action': 'get_movie',
                'id': u'2930',
                'translator_id': u'111',
            },
            headers={
                'Origin': 'http://hdrezka.sh',
                'X-Requested-With': 'XMLHttpRequest',
                'Host': 'hdrezka.sh',
                'Referer': 'https://hdrezka.sh/films/fiction/2930-hraniteli-2009.html',
                'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0',
            }
        )

        print(response.json())
```

Correct request (no error):
```
    with Session() as session:
        data = {
            'id': '2930',
            'translator_id': '111',
            # 'is_camrip': '0',
            # 'is_ads': '0',
            'is_director': '1',
            'action': 'get_movie'
        }

        response = session.post(
            'https://hdrezka.sh/ajax/get_cdn_series/',
            headers={
                'Origin': 'http://hdrezka.sh',
                'X-Requested-With': 'XMLHttpRequest',
                'Host': 'hdrezka.sh',
                'Referer': 'https://hdrezka.sh/films/fiction/2930-hraniteli-2009.html',
                'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0',
            },
            data=data,
        )

        print(response.json())
```

There are also 2 more extra params allowed: is_camrip and is_ads. I haven't checked it hence no changes with it in the code.
