### PR TITLE
Fixed selecting director version

### DIFF
--- a/addons/plugin.video.hdrezka.tv/default.py
+++ b/addons/plugin.video.hdrezka.tv/default.py
@@ -317,9 +317,9 @@ class HdrezkaTV:
             "translator_id": idt,
             "action": action
         }
-        is_director = common.parseDOM(div, 'li', attrs={'data-translator_id': idt}, ret='data-director')
+        is_director = common.parseDOM(div, 'li', ret='data-director')
         if is_director:
-            data['is_director'] = is_director[0]
+            data['is_director'] = is_director[index_]
 
         headers = {
             "Host": self.domain,


### PR DESCRIPTION
Report: http://xbmc.ru/forum/showpost.php?p=163027&postcount=1134

Cause: selector extracts a list of is_director values for all translations with the currently selected translator. however, only the first is_director flag, even if the user selected second one (i.e. translations "Original" and "Original [director cut]" produces a list of values [false, true], and selecting the first element makes it impossible to watch the Original director's cut).

Solution: extract is_director values for all translations and then select by index.