### PR TITLE
Fix hdrezka play episode missing links

### DIFF
--- a/addons/plugin.video.hdrezka.tv/addon.xml
+++ b/addons/plugin.video.hdrezka.tv/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.hdrezka.tv" name="Hdrezka.tv" version="2.5.9" provider-name="MrStealth, dandy, DesSolo">
+<addon id="plugin.video.hdrezka.tv" name="Hdrezka.tv" version="2.5.10" provider-name="MrStealth, dandy, DesSolo">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.xbmc.helpers" version="2.1.0"/>

--- a/addons/plugin.video.hdrezka.tv/default.py
+++ b/addons/plugin.video.hdrezka.tv/default.py
@@ -402,7 +402,7 @@ class HdrezkaTV:
     def play_episode(self, url, referer, post_id, season_id, episode_id, title, image, idt, data):
         log("*** play_episode")
         subtitles = None
-        if (data == "null"):
+        if data == "null" or data == "":
             data = {
                 "id": post_id,
                 "translator_id": idt,


### PR DESCRIPTION
Fix exception on episode play (empty data value)

```
2024-01-18 23:37:31.456 T:1559503744   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IndexError'>
                                            Error Contents: list index out of range
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.hdrezka.tv/default.py", line 435, in <module>
                                                plugin.main()
                                              File "/storage/.kodi/addons/plugin.video.hdrezka.tv/default.py", line 70, in main
                                                urllib.unquote_plus(params['data'])
                                              File "/storage/.kodi/addons/plugin.video.hdrezka.tv/default.py", line 424, in play_episode
                                                links = self.get_links(self.decode_response(data))
                                              File "/storage/.kodi/addons/plugin.video.hdrezka.tv/default.py", line 307, in get_links
                                                manifest_links[int(link.split("]")[0].replace("[", "").replace("p", ""))] = link.split("]")[1]
                                            IndexError: list index out of range
                                            -->End of Python script error report<--
```